### PR TITLE
feat: update Python version support and enhance ISyntax image wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <div align="center">
 
-[![Python](https://img.shields.io/badge/Python-3.8+-blue.svg)](https://python.org)
+[![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![PyPI](https://img.shields.io/badge/PyPI-tissuelab-blue.svg)](https://pypi.org/project/tissuelab/)
 
@@ -45,7 +45,7 @@ with DicomImageWrapper("path/to/image.dcm") as dicom:
 - **DICOM**: Medical imaging standard
 - **NIfTI**: Neuroimaging format
 - **CZI**: Zeiss microscopy format (Windows)
-- **ISyntax**: Philips pathology format (Windows)
+- **ISyntax**: Philips pathology format
 - **Simple Images**: JPEG, PNG, BMP, etc.
 
 ## 🔧 API Reference
@@ -59,7 +59,7 @@ from tissuelab_sdk.wrapper import (
     NiftiImageWrapper,   # NIfTI files
     SimpleImageWrapper,  # JPEG, PNG, etc.
     CziImageWrapper,     # CZI files (Windows)
-    ISyntaxImageWrapper  # ISyntax files (Windows)
+    ISyntaxImageWrapper  # ISyntax files
 )
 
 # All wrappers share the same interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-pillow~=11.0.0
-tifffile>=2023.0.0
-tiffslide
-pydicom>=2.3.0
-numpy==1.26.4
-nibabel>=5.2.0
+pillow>=11.0.0
+tifffile>=2026.3.3
+tiffslide==3.0.0
+pydicom>=3.0.2
+numpy>=1.26.4,<2.0
+nibabel==5.4.2
+pyisyntax==0.1.5
 czifile>=2019.7.2; platform_system == "Windows"
 pylibCZIrw>=3.3.0; platform_system == "Windows"
 pywin32; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pillow>=11.0.0
+pillow>=12.0.0
 tifffile>=2026.3.3
 tiffslide==3.0.0
 pydicom>=3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pillow>=12.0.0
-tifffile>=2026.3.3
-tiffslide==3.0.0
+tifffile==2025.5.10
+tiffslide>=2.5.1,<3.0
 pydicom>=3.0.2
 numpy>=1.26.4,<2.0
 nibabel==5.4.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="tissuelab-sdk",
-    version="0.1.13",
+    version="0.1.14",
     author="TissueLab Team",
     description="TissueLab Python SDK - OS-aware imaging wrappers",
     long_description=long_description,
@@ -20,12 +20,12 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=requirements,
 )
 

--- a/tissuelab_sdk/__init__.py
+++ b/tissuelab_sdk/__init__.py
@@ -3,6 +3,7 @@
 This package provides the public import path `tissuelab_sdk.wrapper`.
 """
 
+__version__ = "0.1.14"
 __all__ = ["wrapper"]
 
 

--- a/tissuelab_sdk/wrapper/__init__.py
+++ b/tissuelab_sdk/wrapper/__init__.py
@@ -6,13 +6,13 @@ package. Import via: `from tissuelab_sdk.wrapper import ...`.
 
 from .common import *  # noqa: F401,F403
 
-# On Windows, expose the extra CZI and ISyntax wrappers
+# On Windows, expose the extra CZI wrapper (requires pylibCZIrw/pythoncom)
 import sys
 
 def _is_windows() -> bool:
     return sys.platform.startswith('win')
 
 if _is_windows():
-    from .windows import CziImageWrapper, ISyntaxImageWrapper  # noqa: F401
+    from .windows import CziImageWrapper  # noqa: F401
 
 

--- a/tissuelab_sdk/wrapper/common.py
+++ b/tissuelab_sdk/wrapper/common.py
@@ -335,7 +335,8 @@ class TiffFileWrapper:
         """return thumbnail, use the smallest page"""
         img = self._tiff.pages[-1].asarray()  # use the smallest page
         pil_img = Image.fromarray(img)
-        return pil_img.thumbnail(size, Image.Resampling.LANCZOS)
+        pil_img.thumbnail(size, Image.Resampling.LANCZOS)
+        return pil_img
 
     def get_best_level_for_downsample(self, downsample: float) -> int:
         """Find the best pyramid level for a given downsample factor.
@@ -852,3 +853,72 @@ class NiftiImageWrapper:
         if as_array:
             return np.array(img)
         return img
+
+
+from isyntax import ISyntax as _ISyntax
+
+
+class ISyntaxImageWrapper:
+    """Wrapper for ISyntax image files using WSI interface (cross-platform)"""
+
+    def __init__(self, isyntax_path):
+        self.path = isyntax_path
+        self.isyntax_reader = None
+        try:
+            self.isyntax_reader = _ISyntax.open(self.path)
+            self._init_levels()
+        except Exception as e:
+            print(f"Error opening ISyntax file {isyntax_path}: {e}")
+            self.dimensions = (100, 100)
+            self.level_count = 1
+            self.level_dimensions = [(100, 100)]
+            self.properties = {
+                'vendor': 'ISyntaxImageWrapper',
+                'dimensions': '100x100',
+                'level_count': '1',
+                'error': str(e)
+            }
+            raise
+
+    def close(self):
+        """Explicitly close the ISyntax reader."""
+        if hasattr(self, 'isyntax_reader') and self.isyntax_reader is not None:
+            try:
+                self.isyntax_reader.close()
+            except Exception as e:
+                print(f"Error closing ISyntax reader: {e}")
+            finally:
+                self.isyntax_reader = None
+
+    def __del__(self):
+        try:
+            if hasattr(self, 'isyntax_reader') and self.isyntax_reader is not None:
+                self.close()
+        except Exception:
+            pass
+
+    def _init_levels(self):
+        if self.isyntax_reader is None:
+            raise RuntimeError("ISyntax reader not initialized")
+        self.dimensions = self.isyntax_reader.dimensions
+        self.level_count = self.isyntax_reader.level_count
+        self.level_dimensions = self.isyntax_reader.level_dimensions
+        self.properties = {
+            'vendor': 'ISyntaxImageWrapper',
+            'dimensions': f'{self.dimensions[0]}x{self.dimensions[1]}',
+            'level_count': str(self.level_count),
+        }
+
+    def read_region(self, location, level, size, as_array=False):
+        """Read a region from the image at the specified level, array type: RGBA"""
+        if self.isyntax_reader is None:
+            raise RuntimeError("ISyntax reader not initialized")
+        scale_factor = self.dimensions[0] / self.level_dimensions[level][0]
+        x, y = location
+        scaled_x = int(x / scale_factor)
+        scaled_y = int(y / scale_factor)
+        scaled_w = int(size[0] / scale_factor)
+        scaled_h = int(size[1] / scale_factor)
+        img_array = self.isyntax_reader.read_region(
+            scaled_x, scaled_y, scaled_w, scaled_h, level)
+        return img_array if as_array else Image.fromarray(img_array, mode='RGBA')

--- a/tissuelab_sdk/wrapper/windows.py
+++ b/tissuelab_sdk/wrapper/windows.py
@@ -1,16 +1,13 @@
 from .common import *  # re-export shared wrappers
 from PIL import Image
 import numpy as np
+import io
 from pylibCZIrw import czi
 import threading
 import time
 import pythoncom
 import czifile
 import xml.etree.ElementTree as ET
-try:
-    from isyntax import ISyntax
-except Exception:  # pragma: no cover
-    ISyntax = None
 class CziImageWrapper:
 
     def __init__(self, czi_path, max_levels=5):
@@ -111,75 +108,3 @@ class CziImageWrapper:
             pil_img = Image.fromarray(img)
             return np.array(pil_img) if as_array else pil_img
 
-
-class ISyntaxImageWrapper:
-    """Wrapper for ISyntax image files using WSI interface"""
-
-    def __init__(self, isyntax_path):
-        self.path = isyntax_path
-        self.isyntax_reader = None
-        try:
-            self.isyntax_reader = ISyntax.open(self.path)
-            self._init_levels()
-        except Exception as e:
-            print(f"Error opening ISyntax file {isyntax_path}: {e}")
-            # Set default values if initialization fails
-            self.dimensions = (100, 100)
-            self.level_count = 1
-            self.level_dimensions = [(100, 100)]
-            self.properties = {
-                'vendor': 'ISyntaxImageWrapper',
-                'dimensions': '100x100',
-                'level_count': '1',
-                'error': str(e)
-            }
-            raise
-    
-    def close(self):
-        """Explicitly close the ISyntax reader."""
-        if hasattr(self, 'isyntax_reader') and self.isyntax_reader is not None:
-            try:
-                self.isyntax_reader.close()
-            except Exception as e:
-                print(f"Error closing ISyntax reader: {e}")
-            finally:
-                self.isyntax_reader = None
-    
-    def __del__(self):
-        """Safe destructor that handles missing attributes."""
-        try:
-            if hasattr(self, 'isyntax_reader') and self.isyntax_reader is not None:
-                self.close()
-        except Exception as e:
-            # Suppress errors during cleanup
-            pass
-
-    def _init_levels(self):
-        if self.isyntax_reader is None:
-            raise RuntimeError("ISyntax reader not initialized")
-        
-        self.dimensions = self.isyntax_reader.dimensions
-        self.level_count = self.isyntax_reader.level_count
-        self.level_dimensions = self.isyntax_reader.level_dimensions
-
-        self.properties = {
-            'vendor': 'ISyntaxImageWrapper',
-            'dimensions': f'{self.dimensions[0]}x{self.dimensions[1]}',
-            'level_count': str(self.level_count),
-        }
-
-    def read_region(self, location, level, size, as_array=False):
-        """Read a region from the image at the specified level, array type: RGBA"""
-        if self.isyntax_reader is None:
-            raise RuntimeError("ISyntax reader not initialized")
-        
-        # convert location and size to integers
-        scale_factor = self.dimensions[0] / self.level_dimensions[level][0]
-        x, y = location
-        scaled_x = int(x / scale_factor)
-        scaled_y = int(y / scale_factor)
-        scaled_w = int(size[0] / scale_factor)
-        scaled_h = int(size[1] / scale_factor)
-        img_array = self.isyntax_reader.read_region(
-            scaled_x, scaled_y, scaled_w, scaled_h, level)
-        return img_array if as_array else Image.fromarray(img_array, mode='RGBA')


### PR DESCRIPTION
This pull request introduces several important updates to the `tissuelab-sdk` package, focusing on expanding cross-platform support for ISyntax image files, updating Python compatibility, and making related documentation and packaging adjustments. The most significant change is moving the `ISyntaxImageWrapper` implementation from Windows-only to a cross-platform wrapper, enabling ISyntax support on all operating systems. Additionally, the minimum required Python version has been increased to 3.10, and the package metadata and documentation have been updated accordingly.

**Cross-platform ISyntax support:**

- Moved the `ISyntaxImageWrapper` implementation from `tissuelab_sdk/wrapper/windows.py` to `tissuelab_sdk/wrapper/common.py`, making it available on all platforms instead of just Windows. The Windows-specific implementation and import logic have been removed

**Python version and packaging updates:**

- Updated the minimum required Python version from 3.8 to 3.10 in `setup.py`, and added support for Python 3.12 and 3.13 in the package classifiers. The package version was bumped to `0.1.14` in both `setup.py` and `tissuelab_sdk/__init__.py`. 
**Documentation improvements:**

- Updated the `README.md` to reflect the new Python version requirement and clarified that ISyntax support is now cross-platform, not limited to Windows. 
**Bug fix:**

- Fixed a bug in the thumbnail generation method of the TIFF wrapper, ensuring the function returns the correct PIL image object instead of `None`.

**Code cleanup:**

- Removed unnecessary conditional imports and legacy code related to ISyntax from the Windows-specific wrapper module.

These changes modernize the package, improve usability across platforms, and ensure compatibility with newer Python versions.